### PR TITLE
Add support for merging after build.

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -63,6 +63,9 @@ correct one. Also make sure to indicate the build number from Jenkins so that
 the link to this build can be constructed.  The build number should be
 available in the `ENV` within `$BUILD_NUMBER`.
 
+Note that this is not to be run from the build. It will not have the correct
+INI file.
+
 ::
 
     cd /$path/to/service/venv/ && \

--- a/setup.py
+++ b/setup.py
@@ -50,7 +50,10 @@ setup(
             'main = jenkinsgithublander.app:main'
         ],
         'console_scripts': [
-            'lander-check-pulls=jenkinsgithublander.scripts.check_pulls:main'
+            ('lander-check-pulls='
+             'jenkinsgithublander.scripts.check_pulls:main'),
+            ('lander-merge-result='
+             'jenkinsgithublander.scripts.merge_result:main'),
         ],
     },
 )

--- a/src/jenkinsgithublander/app.py
+++ b/src/jenkinsgithublander/app.py
@@ -1,13 +1,13 @@
 from pyramid.config import Configurator
 from pyramid.response import Response
 
-from jenkinsgithublander.jobs import merge_pull_requests
+from jenkinsgithublander.jobs import kick_mergeable_pull_requests
 
 
 # Route callables
 def trigger_mergable_commits(request):
     config = request.registry.settings
-    kicked = merge_pull_requests(config)
+    kicked = kick_mergeable_pull_requests(config)
     if kicked:
         ret = "\n".join(kicked)
     else:

--- a/src/jenkinsgithublander/jenkins.py
+++ b/src/jenkinsgithublander/jenkins.py
@@ -12,9 +12,19 @@ class JenkinsError(Exception):
     pass
 
 
+def generate_build_url(number, config):
+    url = config.url.format(config.job)
+    url = url + '/{0}'.format(number)
+    return url
+
+
+def generate_job_url(config):
+    return config.url.format(config.job)
+
+
 def kick_jenkins_merge(pr_id, git_sha, jenkins_info):
     """Trigger a merge build for the pull request specified"""
-    url = jenkins_info.url.format(jenkins_info.job)
+    url = generate_job_url(jenkins_info)
     request_data = {
         'pr': pr_id,
         'sha1': git_sha,

--- a/src/jenkinsgithublander/jobs.py
+++ b/src/jenkinsgithublander/jobs.py
@@ -1,16 +1,22 @@
 from jenkinsgithublander.github import (
+    get_pull_request,
+    GithubError,
     GithubInfo,
+    merge_pull_request,
     mergeable_pull_requests,
+    pull_request_build_failed,
     pull_request_kicked,
 )
 from jenkinsgithublander.jenkins import (
+    generate_build_url,
+    generate_job_url,
     JenkinsError,
     JenkinsInfo,
     kick_jenkins_merge,
 )
 
 
-def merge_pull_requests(config):
+def kick_mergeable_pull_requests(config):
     """Check github for pull requests that include the merge command.
 
     If the merge command is found, the -merge job in jenkins is kicked to
@@ -48,7 +54,7 @@ def merge_pull_requests(config):
                 ))
 
                 # Notify the pull request that we've scheduled a build for it.
-                jenkins_url = jenkins_info.url.format(jenkins_info.job)
+                jenkins_url = generate_job_url(jenkins_info)
                 pull_request_kicked(pr, jenkins_url, github_info)
 
             except JenkinsError as exc:
@@ -60,3 +66,67 @@ def merge_pull_requests(config):
                 )
 
     return kicked
+
+
+def mark_pull_request_build_failed(pr, build_number, failure_message, config):
+    """The given pull request failed to build.
+
+    Comment on the pull request to alert the devs of this issue.
+
+    """
+    github_info = GithubInfo(
+        config['github.owner'],
+        config['github.project'],
+        config['github.username'],
+        config['github.token'],
+    )
+    jenkins_info = JenkinsInfo(
+        config['jenkins.merge.url'],
+        config['jenkins.merge.job'],
+        config['jenkins.merge.token'],
+    )
+
+    pull_request = get_pull_request(pr, github_info)
+    build_url = generate_build_url(build_number, jenkins_info)
+    try:
+        comment = pull_request_build_failed(
+            pull_request,
+            build_url,
+            failure_message,
+            github_info
+        )
+        return comment['url']
+    except GithubError as exc:
+        return 'Failed to add comment: {0}'.format(exc)
+
+
+def do_merge_pull_request(pr, build_number, config):
+    """The given pull build passed and needs to be merged.
+
+    """
+    github_info = GithubInfo(
+        config['github.owner'],
+        config['github.project'],
+        config['github.username'],
+        config['github.token'],
+    )
+    jenkins_info = JenkinsInfo(
+        config['jenkins.merge.url'],
+        config['jenkins.merge.job'],
+        config['jenkins.merge.token'],
+    )
+
+    build_url = generate_build_url(build_number, jenkins_info)
+    try:
+        result = merge_pull_request(
+            pr,
+            build_url,
+            github_info
+        )
+        if result['merged']:
+            return result['message']
+        else:
+            raise GithubError(
+                'Failed to merge: {0}'.format(result['message']))
+    except GithubError as exc:
+        return 'Failed to add comment: {0}'.format(exc)

--- a/src/jenkinsgithublander/scripts/check_pulls.py
+++ b/src/jenkinsgithublander/scripts/check_pulls.py
@@ -3,20 +3,18 @@ from ConfigParser import ConfigParser
 from os import path
 
 from jenkinsgithublander import VERSION
-from jenkinsgithublander.jobs import merge_pull_requests
+from jenkinsgithublander.jobs import kick_mergeable_pull_requests
 
 
 def parse_args():
     """Handle building what we want to do based on the arguments.
 
     Examples:
-        api.py invites list
-        api.py invites set -u username -c 10
-        api.py accounts list --inactive
-        api.py readable list --todo
+        check_pulls.py --version
+        check_pulls.py --ini development.ini
 
     """
-    desc = """Command line client for the Bookie bookmark service.
+    desc = """Check for pull requests ready for building and merging.
 
     """
     parser = argparse.ArgumentParser(description=desc)
@@ -47,7 +45,7 @@ def parse_config(ini):
 
 
 def run(args, config):
-    kicked = merge_pull_requests(config)
+    kicked = kick_mergeable_pull_requests(config)
     if kicked:
         ret = "\n".join(kicked)
     else:

--- a/src/jenkinsgithublander/scripts/merge_result.py
+++ b/src/jenkinsgithublander/scripts/merge_result.py
@@ -1,0 +1,99 @@
+"""Update the pull request given the results of the merge jenkins job.
+
+  default:   then merge the pull request via the api.
+  --failure: then comment on the pull request with information about the
+             failure.
+
+"""
+import argparse
+from ConfigParser import ConfigParser
+from os import path
+from textwrap import dedent
+
+from jenkinsgithublander import VERSION
+from jenkinsgithublander.jobs import (
+    mark_pull_request_build_failed,
+    do_merge_pull_request
+)
+
+
+def parse_args():
+    """Handle building what we want to do based on the arguments.
+
+    Examples:
+        lander-merge-result --version
+        lander-merge-result --ini development.ini --pr=5 --build=25
+        lander-merge-result --ini development.ini \
+                            --failure="Build failed" --pr=5 --build=25
+
+    """
+    desc = """Give a pull request, merge it or comment on the failure in case
+    of a failing build.
+
+    """
+    parser = argparse.ArgumentParser(description=dedent(desc))
+    parser.add_argument(
+        '--version',
+        action='version',
+        version=VERSION)
+
+    parser.add_argument(
+        '-i', '--ini',
+        action='store',
+        required=True,
+        help='Path to the ini file containing the jenkins and github config.'
+    )
+
+    parser.add_argument(
+        '-p', '--pr',
+        action='store',
+        required=True,
+        help='The Github pull request that was tested.'
+    )
+
+    parser.add_argument(
+        '-b', '--build',
+        action='store',
+        required=True,
+        help='The Jenkins build number this result is for.'
+    )
+
+    parser.add_argument(
+        '--failure',
+        action='store',
+        default=None,
+        help='A message indicating the build has failed.'
+    )
+
+    return parser.parse_args()
+
+
+def parse_config(ini):
+
+    if not path.exists(ini):
+        raise Exception('Ini file not found: ' + ini)
+
+    cfg = ConfigParser()
+    cfg.readfp(open(ini))
+
+    return dict(cfg.items('app:main', raw=True))
+
+
+def run(args, config):
+    if args.failure is not None:
+        ret = mark_pull_request_build_failed(
+            args.pr, args.build, args.failure, config)
+    else:
+        ret = do_merge_pull_request(args.pr, args.build, config)
+
+    print ret
+
+
+def main():
+    args = parse_args()
+    cfg = parse_config(args.ini)
+    run(args, cfg)
+
+
+if __name__ == "__main__":
+    main()

--- a/src/jenkinsgithublander/tests/data/github-merge-failed.json
+++ b/src/jenkinsgithublander/tests/data/github-merge-failed.json
@@ -1,0 +1,5 @@
+{
+  "sha": null,
+  "merged": false,
+  "message": "Failure reason"
+}

--- a/src/jenkinsgithublander/tests/data/github-merge-success.json
+++ b/src/jenkinsgithublander/tests/data/github-merge-success.json
@@ -1,0 +1,5 @@
+{
+    "merged": true, 
+    "message": "Pull Request successfully merged", 
+    "sha": "6dcb09b5b57875f334f61aebed695e2e4193db5e"
+}


### PR DESCRIPTION
- Adds the new command lander-merge-result
- Add a job to perform the merge via github api.
- Add a job to submit a comment on the pull request issue if it failed.
- Add support to the github api for marking a failing build, getting a single
  pull request, and performing a merge.
