### PR TITLE
Update to work with non-200 jenkins responses

### DIFF
--- a/src/jenkinsgithublander/jenkins.py
+++ b/src/jenkinsgithublander/jenkins.py
@@ -38,5 +38,7 @@ def kick_jenkins_merge(pr_id, git_sha, jenkins_info):
     }
 
     resp = requests.post(url, request_data)
-    if resp.status_code != 200:
+    try:
+        resp.raise_for_status()
+    except requests.exceptions.HTTPError:
         raise JenkinsError(resp.content)

--- a/src/jenkinsgithublander/tests/test_jenkins.py
+++ b/src/jenkinsgithublander/tests/test_jenkins.py
@@ -76,3 +76,33 @@ class TestJenkinsHelpers(TestCase):
         result = kick_jenkins_merge(4, 'sha1232', info)
 
         self.assertIsNone(result)
+
+    @responses.activate
+    def test_kick_jenkins_merge_201(self):
+        responses.add(
+            responses.POST,
+            'http://jenkins.com/job/one/buildWithParameters',
+            body='',
+            status=201,
+            content_type='application/json'
+        )
+
+        info = JenkinsInfo(
+            'http://jenkins.com/job/{}', 'one', '1234')
+        result = kick_jenkins_merge(4, 'sha1232', info)
+
+        self.assertIsNone(result)
+
+    @responses.activate
+    def test_kick_jenkins_merge_404(self):
+        responses.add(
+            responses.POST,
+            'http://jenkins.com/job/one/buildWithParameters',
+            body='',
+            status=404,
+            content_type='application/json'
+        )
+
+        info = JenkinsInfo(
+            'http://jenkins.com/job/{}', 'one', '1234')
+        self.assertRaises(JenkinsError, kick_jenkins_merge, 4, 'sha1232', info)


### PR DESCRIPTION
- Jenkins started sending back 201 "created" for kicked jobs
- Add a test that it raises the appropriate exception for a 404 response as an
  error case.
- Fixes #10 
