### PR TITLE
Include pull request title in merge commit messages

### DIFF
--- a/src/jenkinsgithublander/github.py
+++ b/src/jenkinsgithublander/github.py
@@ -128,10 +128,14 @@ def merge_pull_request(pr_number, jenkins_url, request_info):
     url = _build_url(merge_url, request_info, {
         'pr_number': pr_number
     })
+
+    commit_message = pr['title'].strip()
+    if pr['body']:
+        commit_message += "\n\n" + pr['body']
     resp = requests.put(
         url,
         data=json.dumps({
-            'commit_message': pr['body']
+            'commit_message': commit_message,
         })
     )
 

--- a/src/jenkinsgithublander/tests/test_github.py
+++ b/src/jenkinsgithublander/tests/test_github.py
@@ -293,6 +293,12 @@ class TestGithubHelpers(TestCase):
             info
         )
 
+        self.assertEqual(len(responses.calls), 2)
+        self.assertEqual(responses.calls[0].request.method, "GET")
+        self.assertEqual(responses.calls[1].request.method, "PUT")
+        self.assertEqual(responses.calls[1].request.body,
+                         '{"commit_message": "here are the changes requested."}')
+
         self.assertEqual(True, result['merged'])
         self.assertEqual("Pull Request successfully merged", result['message'])
 

--- a/src/jenkinsgithublander/tests/test_github.py
+++ b/src/jenkinsgithublander/tests/test_github.py
@@ -297,7 +297,7 @@ class TestGithubHelpers(TestCase):
         self.assertEqual(responses.calls[0].request.method, "GET")
         self.assertEqual(responses.calls[1].request.method, "PUT")
         self.assertEqual(responses.calls[1].request.body,
-                         '{"commit_message": "here are the changes requested."}')
+                         '{"commit_message": "Update hacking\\n\\nhere are the changes requested."}')
 
         self.assertEqual(True, result['merged'])
         self.assertEqual("Pull Request successfully merged", result['message'])


### PR DESCRIPTION
Merge commit messages can look a little odd without the pull request title.
