### PR TITLE
Handle errors on merging via github api better

### DIFF
--- a/src/jenkinsgithublander/__init__.py
+++ b/src/jenkinsgithublander/__init__.py
@@ -1,3 +1,6 @@
 import pkg_resources
 
 VERSION = pkg_resources.get_distribution("jenkins-github-lander").version
+
+class LanderError(Exception):
+    """Base exception type for jenkins github lander related errors"""

--- a/src/jenkinsgithublander/github.py
+++ b/src/jenkinsgithublander/github.py
@@ -4,6 +4,8 @@ import json
 import requests
 from textwrap import dedent
 
+from jenkinsgithublander import LanderError
+
 
 API_URL = 'https://api.github.com'
 GithubInfo = namedtuple(
@@ -13,8 +15,8 @@ GithubInfo = namedtuple(
 MERGE_SCHEDULED = 'merge request accepted'
 
 
-class GithubError(Exception):
-    pass
+class GithubError(LanderError):
+    """Error interacting with the github api"""
 
 
 def _build_url(route, request_info, extra_info=None):

--- a/src/jenkinsgithublander/jobs.py
+++ b/src/jenkinsgithublander/jobs.py
@@ -142,16 +142,11 @@ def do_merge_pull_request(job_name, pr, build_number, config):
     )
 
     build_url = generate_build_url(build_number, jenkins_info)
-    try:
-        result = merge_pull_request(
-            pr,
-            build_url,
-            github_info
-        )
-        if result['merged']:
-            return result['message']
-        else:
-            raise GithubError(
-                'Failed to merge: {0}'.format(result['message']))
-    except GithubError as exc:
-        return 'Failed to add comment: {0}'.format(exc)
+    result = merge_pull_request(
+        pr,
+        build_url,
+        github_info
+    )
+    if result.get("merged", False):
+        return result['message']
+    raise GithubError('Failed to merge: {0}'.format(result))

--- a/src/jenkinsgithublander/scripts/merge_result.py
+++ b/src/jenkinsgithublander/scripts/merge_result.py
@@ -9,8 +9,12 @@ import argparse
 from ConfigParser import ConfigParser
 from os import path
 from textwrap import dedent
+import sys
 
-from jenkinsgithublander import VERSION
+from jenkinsgithublander import (
+    LanderError,
+    VERSION,
+)
 from jenkinsgithublander.jobs import (
     mark_pull_request_build_failed,
     do_merge_pull_request
@@ -104,8 +108,13 @@ def run(args, config):
 def main():
     args = parse_args()
     cfg = parse_config(args.ini)
-    run(args, cfg)
+    try:
+        run(args, cfg)
+    except LanderError as e:
+        sys.stderr.write("ERROR: {}\n".format(e))
+        return 1
+    return 0
 
 
 if __name__ == "__main__":
-    main()
+    sys.exit(main())

--- a/src/jenkinsgithublander/tests/data/github-merge-not-mergeable.json
+++ b/src/jenkinsgithublander/tests/data/github-merge-not-mergeable.json
@@ -1,0 +1,4 @@
+{
+    "documentation_url": "https://developer.github.com/v3/pulls/#merge-a-pull-request-merge-button",
+    "message": "Pull Request is not mergeable"
+}

--- a/src/jenkinsgithublander/tests/test_github.py
+++ b/src/jenkinsgithublander/tests/test_github.py
@@ -3,7 +3,10 @@ import json
 import responses
 from unittest import TestCase
 
-from jenkinsgithublander import github
+from jenkinsgithublander import (
+    github,
+    LanderError,
+)
 from jenkinsgithublander.github import (
     get_open_pull_requests,
     GithubInfo,
@@ -14,6 +17,15 @@ from jenkinsgithublander.github import (
     pull_request_kicked,
 )
 from jenkinsgithublander.tests.utils import load_data
+
+
+class TestGithubError(TestCase):
+
+    def test_github_error(self):
+        """A GithubError can be made, stringified, and is a LanderError"""
+        e = GithubError("Test error")
+        self.assertEqual(str(e), "Test error")
+        self.assertIsInstance(e, LanderError)
 
 
 class TestGithubHelpers(TestCase):


### PR DESCRIPTION
Several improvements to the error handling of the lander-merge-result job.
Returns non-zero error code on failure and prints errors to stderr. Also
copes with a weird api issue where the pr is reported as not mergable but
lacks the 'merged' key in the response.
