### PR TITLE
Support requeuing proposals after a merge failure

### DIFF
--- a/src/jenkinsgithublander/github.py
+++ b/src/jenkinsgithublander/github.py
@@ -10,6 +10,7 @@ GithubInfo = namedtuple(
     'GithubInfo',
     ['owner', 'project', 'username', 'token'])
 
+MERGE_FAILED = 'Build failed: '
 MERGE_SCHEDULED = 'merge request accepted'
 
 
@@ -59,10 +60,14 @@ def _is_mergeable(comments, owner, trigger, request_info):
         if MERGE_SCHEDULED in comment['body']:
             is_merging = True
 
+        # Reset the status if a requested merge failed.
+        if is_merging and MERGE_FAILED in comment['body']:
+            request_merge = False
+            is_merging = False
+
     if request_merge and not is_merging:
         return True
-    else:
-        return False
+    return False
 
 
 def _json_resp(response):

--- a/src/jenkinsgithublander/tests/data/github-pull-request-comments-requeue.json
+++ b/src/jenkinsgithublander/tests/data/github-pull-request-comments-requeue.json
@@ -1,0 +1,34 @@
+[
+  {
+    "id": 1,
+    "user": {
+      "login": "mitechie",
+      "id": 75915
+    },
+    "body": "$$merge$$"
+  },
+  {
+    "id": 2,
+    "user": {
+      "login": "jujugui",
+      "id": 6012845
+    },
+    "body": "Status: merge request accepted. Url: http://jenkins.test/job/github-merge"
+  },
+  {
+    "id": 3,
+    "user": {
+      "login": "jujugui",
+      "id": 6012845
+    },
+    "body": "Build failed: Tests failed\n        build url: http://jenkins.test/job/github-merge/1"
+  },
+  {
+    "id": 4,
+    "user": {
+      "login": "mitechie",
+      "id": 75915
+    },
+    "body": "$$merge$$"
+  }
+]


### PR DESCRIPTION
Look for reports that the merge failed when seeing if a pull request is
mergeable, and obey merge directives following it. The previous scheme
required all users to be admins to remove the 'merge request accepted'
messages from the bot to get it to retry.
