### PR TITLE
Allow use of Jenkins username/password for basic authentication.

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -14,11 +14,11 @@ Process
   the Github pull request builder plugin)
 - Once code receives a LGTM, the author places a keyword "$$merge$$" into a
   final comment on the pull request.
-- This webservice, via a hook notification Github, catches this and triggers a
+- This webservice, via a hook notification from Github, triggers a
   merge job in jenkins.
 - If all tests pass, the Jenkins server will ping back that this pull request
   is good and passes all tests.
-- This web service then triggers a merge via the Github api to land the branch.
+- This web service then triggers a merge via the Github API to land the branch.
 
 
 Install on Jenkins Server

--- a/prototype/Makefile
+++ b/prototype/Makefile
@@ -2,7 +2,7 @@
 WD := $(shell pwd)
 PY := bin/python
 PIP := bin/pip
-
+DEPS_CANARY := lib/.DEPS_CANARY
 
 # #######
 # INSTALL
@@ -18,13 +18,17 @@ bin/python:
 clean_venv:
 	rm -rf bin include lib local man share
 
-deps: venv
+
+deps: $(DEPS_CANARY)
+$(DEPS_CANARY): | venv
 	bin/pip install -r requirements.txt
+	touch $(DEPS_CANARY)
 
 develop:
 	bin/python jenkinsmerger/setup.py develop
 
-run:
+.PHONY: devrun
+devrun:
 	cd jenkinsmerge
 	../bin/pserve development.ini
 
@@ -40,3 +44,7 @@ clean_all: clean_venv
 .PHONY: run
 run:
 	paster
+
+.PHONY: test
+test:	deps
+	bin/nosetests -x -s jenkinsmerger

--- a/prototype/jenkinsmerger/views.py
+++ b/prototype/jenkinsmerger/views.py
@@ -24,19 +24,27 @@ def check_pull_requests(request):
     resp = requests.get(github_url)
     pull_requests = resp.json()
 
+    jenkins_url = config.get('jenkins.merge.url')
+    jenkins_token = config.get('jenkins.merge.token')
+    jenkins_auth_user = config.get('jenkins.merge.user')
+    jenkins_auth_password = config.get('jenkins.merge.password')
+    if jenkins_auth_user and jenkins_auth_password:
+        jenkins_auth = (jenkins_auth_user, jenkins_auth_password)
+    else:
+        jenkins_auth = None
+
     for pull in pull_requests:
-        # Get the list of comments on the PR
+        # Get the list of comments on the PR.
         # They're under the issue created, not the pull request itself.
         comments_url = pull['_links']['comments']['href'] + "?access_token={}"
 
         resp = requests.get(comments_url.format(config.get('github.token')))
         comments = resp.json()
 
-        jenkins_url = config.get('jenkins.merge.url')
         jenkins_payload = {
-            'token': config.get('jenkins.merge.token'),
+            'token': jenkins_token,
             'sha1': pull['head']['sha'],
-            'pr': pull['number']
+            'pr': pull['number'],
         }
 
         # Now we can check each of the comments to see if they contain the
@@ -44,13 +52,14 @@ def check_pull_requests(request):
         # @Todo make sure the user is in the CanonicalJS org.
         for comment in comments:
             if config.get('jenkins.merge.trigger') in comment['body']:
-                resp = requests.post(jenkins_url, params=jenkins_payload)
+                resp = requests.post(
+                    jenkins_url, params=jenkins_payload, auth=jenkins_auth)
                 results.append('Kicking merge for pull request: {}'.format(
-                    pull['number']
+                    pull['number'],
                 ))
             else:
                 results.append('Not going to kick pull request: {}'.format(
-                    pull['number']
+                    pull['number'],
                 ))
 
     return results

--- a/prototype/requirements.txt
+++ b/prototype/requirements.txt
@@ -1,3 +1,4 @@
 pyramid
 requests
-
+nose
+nose-selecttests

--- a/sample.ini
+++ b/sample.ini
@@ -35,6 +35,12 @@ jenkins.merge.token = jenkinstoken
 # "if $trigger in message.content" usage.
 jenkins.merge.trigger = $$merge$$
 
+# If the Jenkins site requires login, the following are the username and
+# password used for basic authentication. The user must exist in Jenkins and
+# have access to the project.
+jenkins.merge.user =
+jenkins.merge.password =
+
 # Which github namespace are we looking for this project. It should
 # be an Organization.
 # Members of this organization must be publicized in order to land merges.

--- a/src/jenkinsgithublander/jenkins.py
+++ b/src/jenkinsgithublander/jenkins.py
@@ -5,7 +5,7 @@ import requests
 
 JenkinsInfo = namedtuple(
     'JenkinsInfo',
-    ['url', 'job', 'token'])
+    ['url', 'job', 'token', 'auth'])
 
 
 class JenkinsError(Exception):
@@ -40,7 +40,7 @@ def kick_jenkins_merge(pr_info, jenkins_info):
         'token': jenkins_info.token,
     }
 
-    resp = requests.post(url, request_data)
+    resp = requests.post(url, request_data, auth=jenkins_info.auth)
     try:
         resp.raise_for_status()
     except requests.exceptions.HTTPError:

--- a/src/jenkinsgithublander/scripts/merge_result.py
+++ b/src/jenkinsgithublander/scripts/merge_result.py
@@ -17,7 +17,7 @@ from jenkinsgithublander import (
 )
 from jenkinsgithublander.jobs import (
     mark_pull_request_build_failed,
-    do_merge_pull_request
+    do_merge_pull_request,
 )
 from jenkinsgithublander.utils import build_config
 


### PR DESCRIPTION
The changes under prototype are not absolutely necessary.  I accidentally started there and then decided to leave them.

Apologies for the compulsive drive-bys which clutter the diff.  (I blame my emacs mode which shows a bunch of lint-y things.)
